### PR TITLE
Export b64toBlob function

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 // TypeScript Version: 2.1
 
 declare module 'b64-to-blob' {
-    function b64toBlob(b64Data: string, contentType?: string): Blob;
+    export function b64toBlob(b64Data: string, contentType?: string): Blob;
     export default b64toBlob;
 }


### PR DESCRIPTION
For those of us who prefer to

`import { b64toBlob } from 'b64-to-blob'`